### PR TITLE
Relax bounds

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -18,7 +18,7 @@ library:
   source-dirs:
   - src
   dependencies:
-  - base >= 4.10 && < 4.12
+  - base >= 4.9 && < 4.12
   - convert
   - containers
   - lens

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: container
-version: 1.1.5
+version: 1.1.6
 synopsis: Containers abstraction and utilities.
 category: Data
 license: Apache-2.0

--- a/package.yaml
+++ b/package.yaml
@@ -18,7 +18,7 @@ library:
   source-dirs:
   - src
   dependencies:
-  - base >= 4.9 && < 4.12
+  - base >= 4.9 && < 4.13
   - convert
   - containers
   - lens


### PR DESCRIPTION
This release fixes the boundaries on `base` such that this library can be used with our version of GHCJS.